### PR TITLE
Correct assignment of the environment vars

### DIFF
--- a/src/Serilog.Enrichers.Environment/Enrichers/EnvironmentUserNameEnricher.cs
+++ b/src/Serilog.Enrichers.Environment/Enrichers/EnvironmentUserNameEnricher.cs
@@ -49,8 +49,8 @@ namespace Serilog.Enrichers
             var userDomainName = Environment.UserDomainName;
             var userName = Environment.UserName;
 #else
-            var userDomainName = Environment.GetEnvironmentVariable("USERNAME");
-            var userName = Environment.GetEnvironmentVariable("USERDOMAIN");
+            var userDomainName = Environment.GetEnvironmentVariable("USERDOMAIN");
+            var userName = Environment.GetEnvironmentVariable("USERNAME");
 #endif
             return !string.IsNullOrWhiteSpace(userDomainName) ? $@"{userDomainName}\{userName}" : userName;
         }


### PR DESCRIPTION
Assignment of vars changed to ensure `EnvironmentUserName` is rendered as {userDomainName}\{userName}