### PR TITLE
Update EnvironmentUserNameEnricher.GetEnvironmentUserName in EnvironmentUserNameEnricher.cs

### DIFF
--- a/src/Serilog.Enrichers.Environment/Enrichers/EnvironmentUserNameEnricher.cs
+++ b/src/Serilog.Enrichers.Environment/Enrichers/EnvironmentUserNameEnricher.cs
@@ -49,8 +49,8 @@ namespace Serilog.Enrichers
             var userDomainName = Environment.UserDomainName;
             var userName = Environment.UserName;
 #else
-            var userDomainName = Environment.GetEnvironmentVariable("USERNAME");
-            var userName = Environment.GetEnvironmentVariable("USERDOMAIN");
+            var userDomainName = Environment.GetEnvironmentVariable("USERDOMAIN");
+            var userName = Environment.GetEnvironmentVariable("USERNAME");
 #endif
             return !string.IsNullOrWhiteSpace(userDomainName) ? $@"{userDomainName}\{userName}" : userName;
         }


### PR DESCRIPTION
The environment variable keys USERNAME and USERDOMAIN were swapped from what seems to have been intended.

Swapped the other way in this change.