### PR TITLE
Adds a Hashed MachineName enricher and extension

### DIFF
--- a/src/Serilog.Enrichers.Environment/Enrichers/HashedMachineNameEnricher.cs
+++ b/src/Serilog.Enrichers.Environment/Enrichers/HashedMachineNameEnricher.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Enrichers
+{
+    /// <summary>
+    /// Enriches log events with a hashed version of a MachineName property containing <see cref="Environment.MachineName"/>.
+    /// The hashed version is usefull as a simple installation correlation Id, when you don't want to or can't expose the 
+    /// machine name due to privacy issues.
+    /// </summary>
+    public class HashedMachineNameEnricher : ILogEventEnricher
+    {
+        LogEventProperty _cachedProperty;
+
+        /// <summary>
+        /// The property name added to enriched log events.
+        /// </summary>
+        public const string HashedMachineNamePropertyName = "HashedMachineName";
+
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            _cachedProperty = _cachedProperty ?? propertyFactory.CreateProperty(HashedMachineNamePropertyName, CalculateMachineNameHash());
+
+            logEvent.AddPropertyIfAbsent(_cachedProperty);
+        }
+
+        private static string CalculateMachineNameHash()
+        {
+#if ENV_USER_NAME
+            var machineName = Environment.MachineName;
+#else
+            var machineName = Environment.GetEnvironmentVariable("COMPUTERNAME");
+            if (string.IsNullOrWhiteSpace(machineName))
+                machineName = Environment.GetEnvironmentVariable("HOSTNAME");
+#endif
+
+            return Convert.ToBase64String(
+                MD5.Create().ComputeHash(
+                    new UTF8Encoding().GetBytes(machineName)));
+        }
+    }
+}

--- a/src/Serilog.Enrichers.Environment/EnvironmentLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Environment/EnvironmentLoggerConfigurationExtensions.cs
@@ -37,6 +37,18 @@ namespace Serilog
         }
 
         /// <summary>
+        /// Enrich log events with an MD5-hashed MachineName property containing the current <see cref="Environment.MachineName"/>.
+        /// </summary>
+        /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
+        /// <returns>Configuration object allowing method chaining.</returns>
+        public static LoggerConfiguration WithHashedMachineName(
+            this LoggerEnrichmentConfiguration enrichmentConfiguration)
+        {
+            if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
+            return enrichmentConfiguration.With<HashedMachineNameEnricher>();
+        }
+
+        /// <summary>
         /// Enriches log events with an EnvironmentUserName property containing [<see cref="Environment.UserDomainName"/>\]<see cref="Environment.UserName"/>.
         /// </summary>
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>

--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Enrich Serilog log events with properties from System.Environment.</Description>
-    <VersionPrefix>2.1.3</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <AssemblyName>Serilog.Enrichers.Environment</AssemblyName>

--- a/test/Serilog.Enrichers.Environment.Tests/Enrichers/HashedEnvironmentMachineNameEnricherTests.cs
+++ b/test/Serilog.Enrichers.Environment.Tests/Enrichers/HashedEnvironmentMachineNameEnricherTests.cs
@@ -1,0 +1,24 @@
+﻿using Serilog.Events;
+using Serilog.Tests.Support;
+using Xunit;
+
+namespace Serilog.Tests.Enrichers
+{
+    public class HashedEnvironmentMachineNameEnricherTests
+    {
+        [Fact]
+        public void HashedEnvironmentMachineNameEnricherIsApplied()
+        {
+            LogEvent evt = null;
+            var log = new LoggerConfiguration()
+                .Enrich.WithHashedMachineName()
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information(@"Has an MachineName property");
+
+            Assert.NotNull(evt);
+            Assert.NotEmpty((string)evt.Properties["HashedMachineName"].LiteralValue());
+        }
+    }
+}


### PR DESCRIPTION
It does pretty much the same as the MachineName enrichment, but hashes the value so that the original value does not appear in logs. We can use it to create a correlation ID based on the machine name, to correlate all logs coming off of the same instalation, without being intrusive.