### PR TITLE
Handles machine names in a safe way

### DIFF
--- a/src/Serilog.Enrichers.Environment/Enrichers/MachineNameEnricher.cs
+++ b/src/Serilog.Enrichers.Environment/Enrichers/MachineNameEnricher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2016 Serilog Contributors
+﻿// Copyright 2013-2018 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,12 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
- 
 
 using System;
 using Serilog.Core;
 using Serilog.Events;
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+#if NETSTANDARD1_3
+using System.Net;
+#endif
 
 namespace Serilog.Enrichers
 {
@@ -39,16 +42,29 @@ namespace Serilog.Enrichers
         /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
-#if ENV_USER_NAME
-            _cachedProperty = _cachedProperty ?? propertyFactory.CreateProperty(MachineNamePropertyName, Environment.MachineName);
-#else
-            var machineName = Environment.GetEnvironmentVariable("COMPUTERNAME");
-            if (string.IsNullOrWhiteSpace(machineName))
-                machineName = Environment.GetEnvironmentVariable("HOSTNAME");
+            logEvent.AddPropertyIfAbsent(GetLogEventProperty(propertyFactory));
+        }
 
-            _cachedProperty = _cachedProperty ?? propertyFactory.CreateProperty(MachineNamePropertyName, machineName);
+        private LogEventProperty GetLogEventProperty(ILogEventPropertyFactory propertyFactory)
+        {
+            // Don't care about thread-safety, in the worst case the field gets overwritten and one
+            // property will be GCed
+            if (_cachedProperty == null)
+                _cachedProperty = CreateProperty(propertyFactory);
+
+            return _cachedProperty;
+        }
+
+        // Qualify as uncommon-path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static LogEventProperty CreateProperty(ILogEventPropertyFactory propertyFactory)
+        {
+#if NETSTANDARD1_3
+            var machineName = Dns.GetHostName();
+#else
+            var machineName = Environment.MachineName;
 #endif
-            logEvent.AddPropertyIfAbsent(_cachedProperty);
+            return propertyFactory.CreateProperty(MachineNamePropertyName, machineName);
         }
     }
-} 
+}

--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -4,7 +4,7 @@
     <Description>Enrich Serilog log events with properties from System.Environment.</Description>
     <VersionPrefix>2.1.3</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard1.5</TargetFrameworks>
     <AssemblyName>Serilog.Enrichers.Environment</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -24,6 +24,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
As pointed out by @syska in https://github.com/serilog/serilog-enrichers-environment/issues/21#issuecomment-350126055 none of the suggested env-variables work. `$HOST` doesn't work on my Linux neither.

[Environment.MachineName](https://docs.microsoft.com/en-us/dotnet/api/system.environment.machinename?view=netstandard-1.5#applies-to) is available since .NET Standard 1.5, so `netstandard1.5` is added to the `TargetFrameworks`.

For .NET Standard 1.3 one way that works on Windows, Linux, raspberry pi (I've verified this). is [System.Net.Dns.GetHostName()](https://stackoverflow.com/a/43961817/347870).
Although this needs a reference to `System.Net.NameResolution` -- also a reason why .NET Standard 1.5 is added, because there no extra references is needed.

| TargetFramework | Method to get machine name | 
| -- | -- |
| net45 | Environment.MachineName |
| netstandard1.3 | Dns.GetHostName |
| netstandard1.5 | Environment.MachineName |

Fixes https://github.com/serilog/serilog-enrichers-environment/issues/21

Plus some rewrite of the code, mainly split in hot- and cold-path.