### PR TITLE
Use Environment.User* on .NET Standard 2.0

### DIFF
--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' AND '$(TargetFramework)' != 'netstandard1.5' ">
     <DefineConstants>$(DefineConstants);ENV_USER_NAME</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Using negative target framework conditions to define the ENV_USER_NAME constant so that if a new target framework is added it will automatically opt-in to ENV_USER_NAME.