### PR TITLE
Allow customisation of the Property Name

### DIFF
--- a/src/Serilog.Enrichers.Environment/Enrichers/MachineNameEnricher.cs
+++ b/src/Serilog.Enrichers.Environment/Enrichers/MachineNameEnricher.cs
@@ -16,7 +16,6 @@ using System;
 using Serilog.Core;
 using Serilog.Events;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 #if NETSTANDARD1_3
 using System.Net;

--- a/src/Serilog.Enrichers.Environment/EnvironmentLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Enrichers.Environment/EnvironmentLoggerConfigurationExtensions.cs
@@ -23,17 +23,18 @@ namespace Serilog
     /// capabilities.
     /// </summary>
     public static class EnvironmentLoggerConfigurationExtensions
-    { 
+    {
         /// <summary>
         /// Enrich log events with a MachineName property containing the current <see cref="Environment.MachineName"/>.
         /// </summary>
         /// <param name="enrichmentConfiguration">Logger enrichment configuration.</param>
+        /// <param name="customPropertyName">Custom property name to override the default of MachineName</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration WithMachineName(
-           this LoggerEnrichmentConfiguration enrichmentConfiguration)
+           this LoggerEnrichmentConfiguration enrichmentConfiguration, string customPropertyName = MachineNameEnricher.DefaultMachineNamePropertyName)
         {
             if (enrichmentConfiguration == null) throw new ArgumentNullException(nameof(enrichmentConfiguration));
-            return enrichmentConfiguration.With<MachineNameEnricher>();
+            return enrichmentConfiguration.With(new MachineNameEnricher(customPropertyName));
         }
 
         /// <summary>

--- a/test/Serilog.Enrichers.Environment.Tests/Enrichers/EnvironmentMachineNameEnricherTests.cs
+++ b/test/Serilog.Enrichers.Environment.Tests/Enrichers/EnvironmentMachineNameEnricherTests.cs
@@ -20,5 +20,22 @@ namespace Serilog.Tests.Enrichers
             Assert.NotNull(evt);
             Assert.NotEmpty((string)evt.Properties["MachineName"].LiteralValue());
         }
+
+        [Fact]
+        public void EnvironmentCustomMachineNameEnricherIsApplied()
+        {
+            string customPropertyName = "host";
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Enrich.WithMachineName(customPropertyName)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information(@"Has an MachineName property");
+
+            Assert.NotNull(evt);
+            Assert.NotEmpty((string)evt.Properties["host"].LiteralValue());
+        }
     }
 }


### PR DESCRIPTION
Simple change to allow the consumer to specify a custom value for the PropertyName. Had a requirement for this so as to keep the log entries consistent between co-operating applications.