### PR TITLE
Update to Serilog 3 and update TFMs

### DIFF
--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Enrich Serilog log events with properties from System.Environment.</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net471;netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Serilog.Enrichers.Environment</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -22,19 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' AND '$(TargetFramework)' != 'netstandard1.5' ">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);ENV_USER_NAME</DefineConstants>
   </PropertyGroup>
 

--- a/test/Serilog.Enrichers.Environment.Tests/Serilog.Enrichers.Environment.Tests.csproj
+++ b/test/Serilog.Enrichers.Environment.Tests/Serilog.Enrichers.Environment.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net48</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net7.0;net6.0;net5.0;netcoreapp3.1;</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Usual question about TFMs to target that pop up in all the repos - should it be a complete match for Serilog 3.0, or a smaller set of what's needed?

In this draft:

Both Framework 4.6.2 and 4.7.1 to create an explicit reference to the 4.7.1 version of the core lib that doesn't depend on the System.ValueTuple nuget package

.NET 6 as the oldest supported .NET Core version, and to explicity use the .NET Core versions of the Serilog core lib (avoids the dependencies on System.Diagnostics.DiagnosticSource in the latest versions

.NET Standard 2.0 for everything else.

So question - is there a need for .NET Standard 2.1 / NET 5.0/7.0 etc?

Note: The TFMs in the unit test project are just set to match the core Serilog lib