### PR TITLE
Update test libraries

### DIFF
--- a/test/Serilog.Enrichers.Environment.Tests/Serilog.Enrichers.Environment.Tests.csproj
+++ b/test/Serilog.Enrichers.Environment.Tests/Serilog.Enrichers.Environment.Tests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.5.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Note: xunit.runner.visualstudio left at the existing version as newer versions don't support .NET 4.6.0 any more, so it needs a call on #55 doing first