### PR TITLE
Readd project properties to sign the assembly

### DIFF
--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -4,6 +4,8 @@
         <Description>Enrich Serilog log events with properties from System.Environment.</Description>
         <VersionPrefix>3.0.1</VersionPrefix>
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
         <Authors>Serilog Contributors</Authors>
         <!-- .NET Framework version targeting is frozen at these two TFMs. -->
         <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
@@ -24,13 +26,13 @@
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="Serilog" Version="4.0.0" />
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <None Include="../../assets/serilog-enricher-nuget.png" Pack="true" Visible="false" PackagePath="/" />
         <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />

--- a/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
+++ b/src/Serilog.Enrichers.Environment/Serilog.Enrichers.Environment.csproj
@@ -6,6 +6,7 @@
         <AssemblyVersion>3.0.0.0</AssemblyVersion>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <Authors>Serilog Contributors</Authors>
         <!-- .NET Framework version targeting is frozen at these two TFMs. -->
         <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>


### PR DESCRIPTION
The project file's assembly signing configuration was unintentionally removed in a recent commit.  This PR adds back the signing project properties to `Serilog.Enrichers.Environment.csproj`.

@nblumhardt I saw that the dev branch was already revved to version 3.0.1, and since it has not yet been merged into main, I left the version number unchanged.